### PR TITLE
[#1] Handle mismatch between model.config.vocab_size and tokenizer.vocab_size

### DIFF
--- a/src/axtk/generation_utils/logits_processors/acceptable_logits_processor.py
+++ b/src/axtk/generation_utils/logits_processors/acceptable_logits_processor.py
@@ -23,6 +23,10 @@ class AcceptableLogitsProcessor:
         self.bias_vector = torch.zeros(self.tokenizer.vocab_size)
 
     def __call__(self, input_ids, scores):
+        # sometimes the model has a vocab_size that is bigger than the tokenizer
+        # so that the embedding matrix can have a length that is a power of 2,
+        # but these extra tokens are never used
+        scores = scores[:, :self.tokenizer.vocab_size]
         # handle 1D inputs
         input_ids, scores, one_dim = self.handle_dimensions(input_ids, scores)
         # update processor state

--- a/src/axtk/generation_utils/logits_processors/bias_logits_processor.py
+++ b/src/axtk/generation_utils/logits_processors/bias_logits_processor.py
@@ -8,5 +8,9 @@ class BiasLogitsProcessor:
             self.bias_vector[token_id] = bias
 
     def __call__(self, input_ids, scores):
+        # sometimes the model has a vocab_size that is bigger than the tokenizer
+        # so that the embedding matrix can have a length that is a power of 2,
+        # but these extra tokens are never used
+        scores = scores[:, :self.tokenizer.vocab_size]
         scores = to_tensor(scores)
         return scores + self.bias_vector

--- a/src/axtk/generation_utils/logits_processors/token_healing_logits_processor.py
+++ b/src/axtk/generation_utils/logits_processors/token_healing_logits_processor.py
@@ -72,6 +72,10 @@ class TokenHealingLogitsProcessor:
         self.num_extensions = 0
 
     def __call__(self, input_ids, scores):
+        # sometimes the model has a vocab_size that is bigger than the tokenizer
+        # so that the embedding matrix can have a length that is a power of 2,
+        # but these extra tokens are never used
+        scores = scores[:, :self.tokenizer.vocab_size]
 
         # we only bias the first token generated
         if self.num_extensions >= len(self.extension_tokens):


### PR DESCRIPTION
It's also possible to avoid the error described in the #1 by resizing the model's token embeddings, feel free to close this PR if that's the preferred solution.

```
model.resize_token_embeddings(tokenizer.vocab_size)
```